### PR TITLE
fix type error

### DIFF
--- a/Model/JobRepository.php
+++ b/Model/JobRepository.php
@@ -310,7 +310,7 @@ class JobRepository implements \Mailjet\Mailjet\Api\JobRepositoryInterface
                         $error = $this->errorFactory->create();
                         $error->setApiResult(json_encode($connection->getResponce()->getBody()));
                         $error->setStatus($connection->getResponce()->getStatus());
-                        $errors[] = $this->errorRepository->save($error);
+                        $errors[] = $this->errorRepository->save($error)->getId();
                     }
                 }
             } elseif ($job->getAction() == \Mailjet\Mailjet\Api\Data\SubscriberQueueInterface::ACTIONS['STK']) {


### PR DESCRIPTION
PHP Fatal error: Object of class Mailjet\Mailjet\Model\Error could not be converted to string in vendor/mailjet/mailjet-magento2/Model/JobRepository.php on line 330