### PR TITLE
Laminas module version

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -3,6 +3,7 @@
 namespace Mailjet\Mailjet\Helper;
 
 use Mailjet\Mailjet\Helper\MailjetAPI as MailjetAPI;
+use Laminas\Http\Client\Adapter\Socket;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
@@ -258,9 +259,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     private $encryptor;
 
     /**
-     * @var \Zend\Http\Client\Adapter\Socket
+     * @var Socket
      */
-    private $zendHttpClient;
+    private $httpClient;
 
     /**
      * Data constructor.
@@ -270,7 +271,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @param \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList
      * @param \Magento\Framework\UrlInterface $urlBuilder
      * @param \Magento\Framework\Encryption\Encryptor $encryptor
-     * @param \Zend\Http\Client\Adapter\Socket $zendHttpClient
+     * @param Socket $httpClient
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context                        $context,
@@ -278,13 +279,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Framework\App\Cache\TypeListInterface               $cacheTypeList,
         \Magento\Framework\UrlInterface                              $urlBuilder,
         \Magento\Framework\Encryption\Encryptor                      $encryptor,
-        \Zend\Http\Client\Adapter\Socket                             $zendHttpClient
+        Socket                                                       $httpClient
     ) {
         $this->config = $config;
         $this->cacheTypeList = $cacheTypeList;
         $this->urlBuilder = $urlBuilder;
         $this->encryptor = $encryptor;
-        $this->zendHttpClient = $zendHttpClient;
+        $this->httpClient = $httpClient;
 
         parent::__construct($context);
     }
@@ -387,12 +388,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function testSmtpConnection($port, $ssl)
     {
         try {
-            $this->zendHttpClient->setOptions(['ssltransport' => $ssl, 'timeout' => 5]);
+            $this->httpClient->setOptions(['ssltransport' => $ssl, 'timeout' => 5]);
 
             if ($ssl == 'tls') {
-                $this->zendHttpClient->connect(\Mailjet\Mailjet\Helper\Data::SMTP_HOST, $port);
+                $this->httpClient->connect(\Mailjet\Mailjet\Helper\Data::SMTP_HOST, $port);
             } else {
-                $this->zendHttpClient->connect('ssl://' . \Mailjet\Mailjet\Helper\Data::SMTP_HOST, $port);
+                $this->httpClient->connect('ssl://' . \Mailjet\Mailjet\Helper\Data::SMTP_HOST, $port);
             }
 
             return true;

--- a/Model/Framework/Mail/Transport.php
+++ b/Model/Framework/Mail/Transport.php
@@ -2,47 +2,50 @@
 
 namespace Mailjet\Mailjet\Model\Framework\Mail;
 
+use Magento\Framework\Exception\MailException;
+use Magento\Framework\Mail\EmailMessageInterface;
+use Magento\Framework\Phrase;
+use Mailjet\Mailjet\Helper\Data;
+use Laminas\Mail\Message;
+use Laminas\Mail\Transport\Smtp;
+use Laminas\Mail\Transport\SmtpOptions;
+
 class Transport
 {
     /**
-     * @var \Mailjet\Mailjet\Helper\Data
+     * @var Data
      */
     protected $dataHelper;
 
     /**
-     * @var \Magento\Framework\Escaper
-     */
-    protected $escaper;
-
-    /**
      * Transport model construct
      *
-     * @param \Mailjet\Mailjet\Helper\Data $dataHelper
-     * @param \Magento\Framework\Escaper   $escaper
+     * @param Data $dataHelper
      */
     public function __construct(
-        \Mailjet\Mailjet\Helper\Data $dataHelper,
-        \Magento\Framework\Escaper $escaper
+        Data $dataHelper
     ) {
         $this->dataHelper = $dataHelper;
-        $this->escaper    = $escaper;
     }
 
     /**
      * Send smtp message
      *
-     * @param \Magento\Framework\Mail\EmailMessageInterface|\Zend\Mail\Message $message
+     * @param EmailMessageInterface|Message $message
      * @param array $config
+     *
      * @return bool
+     *
+     * @throws MailException
      */
     public function sendSmtpMessage($message, $config)
     {
-        if (!($message instanceof \Zend\Mail\Message)) {
-            $message = \Zend\Mail\Message::fromString($message->getRawMessage());
+        if (!($message instanceof Message)) {
+            $message = Message::fromString($message->getRawMessage());
         }
 
         //set config
-        $options   = new \Zend\Mail\Transport\SmtpOptions(
+        $options = new SmtpOptions(
             [
             // 'name' => '',
             'host' => $config['host'],
@@ -52,31 +55,21 @@ class Transport
 
         $options->setConnectionClass('login');
 
-        $connectionConfig = [
-            'username' => $config['username'],
-            'password' => $config['password'],
-            'ssl'      => $config['ssl'],
-        ];
-
-        $options->setConnectionConfig($connectionConfig);
+        $options->setConnectionConfig(
+            [
+                'username' => $config['username'],
+                'password' => $config['password'],
+                'ssl'      => $config['ssl'],
+            ]
+        );
 
         try {
-            $transport = new \Zend\Mail\Transport\Smtp();
+            $transport = new Smtp();
             $transport->setOptions($options);
             $transport->send($message);
-            $toArr = [];
-
-            foreach ($message->getTo() as $toAddr) {
-                $toArr[] = $toAddr->getEmail();
-            }
-
-            $data['recipient'] = implode(',', $toArr);
-            $data['sender'] = $message->getFrom()->rewind()->getEmail();
-            $data['subject'] = $message->getSubject();
-            $data['body'] = $this->escaper->escapeHtml($message->toString());
 
             return true;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             throw new MailException(
                 new Phrase($e->getMessage()),
                 $e

--- a/Plugin/Email/Model/Transport.php
+++ b/Plugin/Email/Model/Transport.php
@@ -6,6 +6,7 @@ use Magento\Framework\Exception\MailException;
 use Magento\Store\Model\ScopeInterface;
 use Mailjet\Mailjet\Helper\Data;
 use Magento\Email\Model\Transport as ModelTransport;
+use Laminas\Mail\Message;
 
 class Transport
 {
@@ -72,19 +73,18 @@ class Transport
             );
 
             try {
-
-                $zendMessage = \Zend\Mail\Message::fromString(
+                $messageObject = Message::fromString(
                     $subject->getMessage()->getRawMessage()
                 )->setEncoding('utf-8');
                 if (2 === $isSetReturnPath && $returnPathValue) {
-                    $zendMessage->setSender($returnPathValue);
-                } elseif (1 === $isSetReturnPath && $zendMessage->getFrom()->count()) {
-                    $fromAddressList = $zendMessage->getFrom();
+                    $messageObject->setSender($returnPathValue);
+                } elseif (1 === $isSetReturnPath && $messageObject->getFrom()->count()) {
+                    $fromAddressList = $messageObject->getFrom();
                     $fromAddressList->rewind();
-                    $zendMessage->setSender($fromAddressList->current()->getEmail());
+                    $messageObject->setSender($fromAddressList->current()->getEmail());
                 }
 
-                $smtp->sendSmtpMessage($zendMessage, $config);
+                $smtp->sendSmtpMessage($messageObject, $config);
             } catch (\Exception $e) {
                 throw new MailException(new \Magento\Framework\Phrase($e->getMessage()), $e);
             }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,8 @@
     "type": "magento2-module",
     "version": "1.0.1",
     "require": {
-        "mailjet/mailjet-apiv3-php": "*"
+        "mailjet/mailjet-apiv3-php": "*",
+        "laminas/laminas-http": "*",
+        "laminas/laminas-mail": "*"
     }
 }


### PR DESCRIPTION
Hello,

Concerning the #11 issue, I've made a commit to correct the following :
- Change the dependency from Zend to Laminas modules (Mail and HTTP).
- Renaming "zend" prefixed variables to more standard names
- Removal of unused $data array computation code in Mail/Transport.php
- Addition of _use_ instructions in Mail/Transport.php
- Addition of composer dependency to laminas-mail and laminas-http modules (No version constraint because I have no history of those modules versions)

As the laminas-mail module is discontinued, I'm assuming that a version check is not relevant.
For the laminas-http module, I'm assuming that the Laminas\Http\Client\Adapter\Socket will be kept as is for now.

The dependencies in the composer.json are not required as no real dependency was given until now (Even tho the Magento\Framework and Zend\Http and Zend\Mail were required).

Do not hesitate if you have any change you want me to do before merging.

Regards,
Baptiste